### PR TITLE
Please loosen up version dependency for Symfony

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "symfony/symfony": "2.1.*",
+        "symfony/framework-bundle": "~2.1",
         "doctrine/orm": ">=2.2.3,<2.4-dev"
     },
     "autoload": {


### PR DESCRIPTION
Seems to work in Symfony 2.3. I have been using it for some time now without any problems.
