### PR TITLE
add ability to specify search configuration for ts_query command

### DIFF
--- a/DQL/TsqueryFunction.php
+++ b/DQL/TsqueryFunction.php
@@ -5,13 +5,14 @@ use Doctrine\ORM\Query\AST\Functions\FunctionNode;
 use Doctrine\ORM\Query\Lexer;
 
 /**
- * TsqueryFunction ::= "TSQUERY" "(" StringPrimary "," StringPrimary ")"
+ * TsqueryFunction ::= "TSQUERY" "(" StringPrimary "," StringPrimary "[, " StringPrimary "])"
  */
 class TsqueryFunction extends FunctionNode
 {
     public $fieldName = null;
     public $queryString = null;
-
+    public $configuration = null;
+    
     public function parse(\Doctrine\ORM\Query\Parser $parser)
     {
         $parser->match(Lexer::T_IDENTIFIER);
@@ -19,13 +20,26 @@ class TsqueryFunction extends FunctionNode
         $this->fieldName = $parser->StringPrimary();
         $parser->match(Lexer::T_COMMA);
         $this->queryString = $parser->StringPrimary();
+        
+        $lexer = $parser->getLexer();
+        if ($lexer->isNextToken(Lexer::T_COMMA)) {
+            $parser->match(Lexer::T_COMMA);
+            $this->configuration = $parser->StringPrimary();
+        }
+        
         $parser->match(Lexer::T_CLOSE_PARENTHESIS);
     }
 
     public function getSql(\Doctrine\ORM\Query\SqlWalker $sqlWalker)
     {
-        return 
-        	$this->fieldName->dispatch($sqlWalker) . 
-            ' @@ to_tsquery(' . $this->queryString->dispatch($sqlWalker) . ')';
+        if ($this->configuration) {
+            $stmnt = $this->fieldName->dispatch($sqlWalker) .  " @@ to_tsquery(" . $this->configuration->dispatch($sqlWalker) . ", " . $this->queryString->dispatch($sqlWalker) . ")";
+        }
+        else {
+            $stmnt = $this->fieldName->dispatch($sqlWalker) .  " @@ to_tsquery(" . $this->queryString->dispatch($sqlWalker) . ")";
+        }
+        
+        return $stmnt;
+        	
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "ddmaster/postgre-search-bundle",
+    "name": "styleflasher/postgre-search-bundle",
     "type": "symfony-bundle",
     "description": "Tools to use full-text search PostgreSQL in Doctrine.",
     "keywords": ["doctrine2", "symfony2", "search", "postgresql"],


### PR DESCRIPTION
Added third optional parameter in TSQUERY to allow usage of text search configuration other than 'default'. See http://www.postgresql.org/docs/8.3/static/textsearch-intro.html#TEXTSEARCH-INTRO-CONFIGURATIONS.