### PR TITLE
Fix issue with TsvectorType.php

### DIFF
--- a/Dbal/TsvectorType.php
+++ b/Dbal/TsvectorType.php
@@ -38,4 +38,9 @@ class TsvectorType extends Type
         }
         return $value;
     }
+ 
+    public function requiresSQLCommentHint(AbstractPlatform $platform)
+    {
+        return true;
+    }
 }


### PR DESCRIPTION
Fixes:

```
User Deprecated: The type "tsvector" was implicitly marked as commented due to the configuration. This is deprecated and will be removed in DoctrineBundle 2.0. 
Either set the "commented" attribute in the configuration to "false" or mark the type as commented in "Ddmaster\\PostgreSearchBundle\\Dbal\\TsvectorType::requiresSQLCommentHint().
```